### PR TITLE
Add key prop and move checkpoint rendering in a method

### DIFF
--- a/src/component/ProgressBar/ProgressBar.component.js
+++ b/src/component/ProgressBar/ProgressBar.component.js
@@ -3,35 +3,40 @@ import { STEPS } from 'Route/Checkout/Checkout.config';
 import "./ProgressBar.style"
 
 class ProgressBar extends PureComponent {
+  renderCheckpoints(stepIndex) {
+    return STEPS.map((el, index) => {
+      // I use the index of the current step to determine if a checkpoint is active and/or completed
+      const isActive = stepIndex >= index ? 'active' : "";
+      const isCompleted = index < stepIndex;
+
+      // The last step renders only a progress line without the checkpoint
+      if (index !== STEPS.length - 1) {
+        return (
+          <div className='step-container' key={el}>
+            <div className={`line ${isActive}`}></div>
+            <div className={`step ${isActive}`}>{isCompleted ? <span>&#10003;</span> : index + 1}</div>
+          </div>
+        )
+      } else {
+        return (
+          <div className='step-container' key={el}>
+            <div className={`line ${isActive}`}></div>
+          </div>
+        )
+      }
+    })
+  }
+
   render() {
     // In checkout.config, I export all the checkout steps in an array to determine the number of checkpoints
-    // and use the checkoutStep prop to determine the active checkpoint
+    // and use the checkoutStep prop to determine the index of the current step
     const { checkoutStep } = this.props;
-    const active = STEPS.indexOf(checkoutStep);
+    const stepIndex = STEPS.indexOf(checkoutStep);
 
     return (
       <div id="progress-container">
         <div id="progress-bar">
-          {STEPS.map((el, index) => {
-            const isActive = active >= index ? 'active' : "";
-            const isCompleted = index < active;
-
-            // The last step renders only a progress line without the checkpoint
-            if (index !== STEPS.length - 1) {
-              return (
-                <div className='step-container'>
-                  <div className={`line ${isActive}`}></div>
-                  <div className={`step ${isActive}`} key={el}>{isCompleted ? <span>&#10003;</span> : index + 1}</div>
-                </div>
-              )
-            } else {
-              return (
-                <div className='step-container'>
-                  <div className={`line ${isActive}`}></div>
-                </div>
-              )
-            }
-          })}
+          {this.renderCheckpoints(stepIndex)}
         </div>
       </div>
     )


### PR DESCRIPTION
In this PR I have:

- Added a key to the list of steps that are rendered for the progress bar
- Moved the rendering of the list in a renderCheckpoints method
- Renamed the active variable into stepIndex and added updated the comments for more clarity